### PR TITLE
Disable source GnuPG checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,6 @@ $(DESTDIR)/var/lib/chaotic/interfere:
 $(DESTDIR)/var/cache/chaotic:
 	@install -dm755 $@
 
-$(DESTDIR)/etc/chaotic/gnupg:
-	@install -o root -g root -dm700 $@
-	gpg --homedir "$@" --recv-keys 8A9E14A07010F7E3
-
 $(DESTDIR)/usr/lib/systemd/system/%: services/%
 	install -o root -g root -m755 $< $@
 
@@ -76,8 +72,7 @@ install: \
 	$(DESTDIR)$(PREFIX)/bin/chaotic.sh \
 	$(DESTDIR)$(PREFIX)/bin/chaotic \
 	$(DESTDIR)/var/lib/chaotic/interfere \
-	$(DESTDIR)/var/cache/chaotic \
-	$(DESTDIR)/etc/chaotic/gnupg
+	$(DESTDIR)/var/cache/chaotic
 
 install-services: \
 	$(foreach s, $(ROUTINES), $(DESTDIR)/usr/lib/systemd/system/chaotic-${s}.service) \

--- a/README.md
+++ b/README.md
@@ -52,11 +52,6 @@ If at some point you see something that could be better, then please open a PR. 
   Download listed packages' sources from AUR.
   Uses `repoctl`.
 
-- `chaotic {kt,key-trust} ${KEYS[@]}`
-
-  Add some key to keyring.
-  Uses `gpg`
-
 - `chaotic cl{,eanup} ${INPUTDIR}`
 
   Safely deletes old package sources.

--- a/src/chaotic.sh
+++ b/src/chaotic.sh
@@ -10,7 +10,6 @@ CAUR_PREFIX="$(pwd -P)"
 popd || exit 2
 
 CAUR_DB_NAME='chaotic-aur'
-CAUR_GUEST_GNUPG='/etc/chaotic/gnupg'
 CAUR_INTERFERE='/var/lib/chaotic/interfere'
 
 CAUR_ADD_DEST="builds.garudalinux.org:~/chaotic/queues/$(whoami)/"
@@ -86,9 +85,6 @@ function main() {
     ;;
   'aur-download' | 'get')
     aur-download "${_PARAMS[@]}"
-    ;;
-  'key-trust' | 'kt')
-    key-trust "${_PARAMS[@]}"
     ;;
   'cleanup' | 'cl')
     cleanup "${_PARAMS[@]}"

--- a/src/lib/base-make.sh
+++ b/src/lib/base-make.sh
@@ -49,16 +49,6 @@ EOF
 
   install -dm755 -o"${CAUR_GUEST_UID}" -g"${CAUR_GUEST_GID}" \
     "./home/$CAUR_GUEST_USER/"{pkgwork,.ccache,pkgdest,pkgsrc,makepkglogs}
-  install -dm700 -o"${CAUR_GUEST_UID}" -g"${CAUR_GUEST_GID}" \
-    "./home/$CAUR_GUEST_USER/.gnupg"
-  install -Dm700 -o"${CAUR_GUEST_UID}" -g"${CAUR_GUEST_UID}" \
-    "$CAUR_GUEST_GNUPG"/{pubring.kbx,trustdb.gpg} \
-    "./home/$CAUR_GUEST_USER/.gnupg/"
-  install -dm700 -o"${CAUR_GUEST_UID}" -g"${CAUR_GUEST_UID}" \
-    "./home/$CAUR_GUEST_USER/.gnupg/crls.d"
-  install -Dm700 -o"${CAUR_GUEST_UID}" -g"${CAUR_GUEST_UID}" \
-    "$CAUR_GUEST_GNUPG/crls.d/DIR.txt" \
-    "./home/$CAUR_GUEST_USER/.gnupg/crls.d/"
 
   popd # _CURRENT
   ln -s "./$_CURRENT" "./latest"

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -66,7 +66,7 @@ function interference-generic() {
 function interference-makepkg() {
   set -euo pipefail
 
-  $CAUR_PUSH exec /usr/local/bin/internal-makepkg -s --noprogressbar "$@" "${TARGET_ARGS:-}" \$\@
+  $CAUR_PUSH exec /usr/local/bin/internal-makepkg -s --noprogressbar --skippgpcheck "$@" "${TARGET_ARGS:-}" \$\@
 
   return 0
 }

--- a/src/lib/keyring.sh
+++ b/src/lib/keyring.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-function key-trust() {
-  gpg --homedir "${CAUR_GUEST_GNUPG}" \
-    --keyserver 'keys.gnupg.net' \
-    --recv-keys "$@"
-}


### PR DESCRIPTION
It is worthless as currently implemented, because sources from any package could be signed using keys from sources of any other package. In the future, we will implement this in a per-package basis.