### PR TITLE
Move pkgdest to /var/pkgdest

### DIFF
--- a/guest/Singularity
+++ b/guest/Singularity
@@ -30,4 +30,5 @@ EOF
   useradd -Uu 1000 -m -s /bin/bash "main-builder"
 
   install -dm755 -o"1000" -g"1000" \
-    "/home/main-builder/"{pkgwork,.ccache,pkgdest,pkgsrc,makepkglogs}
+    "/home/main-builder/"{pkgwork,.ccache,pkgsrc,makepkglogs} \
+    '/var/pkgdest'

--- a/guest/bin/internal-makepkg
+++ b/guest/bin/internal-makepkg
@@ -9,6 +9,7 @@ export SHELL='/bin/bash'
 export TERM='dumb'
 
 chown -R "$USER":"$USER" "${HOME}"
+chown "$USER":"$USER" '/var/pkgdest'
 
 cd "${HOME}/pkgwork"
 deps="$(su main-builder -- internal-makepkg-depends)"

--- a/guest/etc/makepkg.conf
+++ b/guest/etc/makepkg.conf
@@ -111,7 +111,7 @@ DBGSRCDIR="/usr/src/debug"
 # Default: put built package and cached source in build directory
 #
 #-- Destination: specify a fixed directory where all packages will be placed
-PKGDEST=/home/main-builder/pkgdest
+PKGDEST=/var/pkgdest
 #-- Source cache: specify a fixed directory where source files will be cached
 SRCDEST=/home/main-builder/pkgsrc
 #-- Source packages: specify a fixed directory where all src packages will be placed

--- a/src/chaotic.sh
+++ b/src/chaotic.sh
@@ -25,7 +25,6 @@ CAUR_DEST_LAST="/srv/http/chaotic-aur/lastupdate"
 CAUR_DEST_PKG="/srv/http/${CAUR_DB_NAME}/x86_64"
 CAUR_GUEST="${CAUR_PREFIX}/lib/chaotic/guest"
 CAUR_LIB="${CAUR_PREFIX}/lib/chaotic"
-CAUR_HACK_USEOVERLAYDEST=1
 CAUR_LOWER_DIR='/var/cache/chaotic/lower'
 CAUR_LOWER_PKGS=(base base-devel)
 CAUR_SANDBOX='/tmp/chaotic/sandbox'
@@ -35,7 +34,7 @@ CAUR_SIGN_USER='root' # who owns the key in gnupg's keyring.
 CAUR_TYPE='primary'   # only the primary cluster manages the database.
 CAUR_URL="http://localhost/${CAUR_DB_NAME}/x86_64"
 CAUR_GPG_PATH="/usr/bin/gpg"
-CAUR_OVERLAY_TYPE='fuse'
+CAUR_OVERLAY_TYPE='kernel'
 
 # shellcheck source=/dev/null
 [[ -f '/etc/chaotic.conf' ]] && source '/etc/chaotic.conf'
@@ -57,7 +56,7 @@ done
 function main() {
   set -euo pipefail
 
-  local _CMD 
+  local _CMD
 
   _CMD="${1:-}"
   # Note: there is usage of "${@:2}" below.

--- a/src/lib/base-make.sh
+++ b/src/lib/base-make.sh
@@ -25,6 +25,8 @@ function lowerstrap() {
 }
 
 function lowerstrap-systemd-nspawn() {
+  set -euo pipefail
+
   local _CURRENT
 
   mkdir -p "$CAUR_LOWER_DIR"
@@ -61,7 +63,8 @@ useradd -Uu 1000 -m -s /bin/bash "main-builder"
 EOF
 
   install -dm755 -o"1000" -g"1000" \
-    "./home/main-builder/"{pkgwork,.ccache,pkgdest,pkgsrc,makepkglogs}
+    "./home/main-builder/"{pkgwork,.ccache,pkgsrc,makepkglogs} \
+    './var/pkgdest'
 
   popd # _CURRENT
   ln -sf "./$_CURRENT" "./latest"
@@ -71,6 +74,8 @@ EOF
 }
 
 function lowerstrap-singularity() {
+  set -euo pipefail
+
   local _CURRENT
 
   _CURRENT="$(date +%Y%m%d%H%M%S).sif"

--- a/src/lib/cleanup.sh
+++ b/src/lib/cleanup.sh
@@ -29,7 +29,7 @@ function cleanup() {
   if [[ "$CAUR_ENGINE" = 'singularity' ]]; then
     singularity --silent exec --fakeroot -B "${_INPUTDIR}:/inputdir" docker://alpine chown -R 0:0 /inputdir
   fi
-  
+
   rm --one-file-system -rf "${_INPUTDIR}"
 
   return 0

--- a/src/lib/deploy.sh
+++ b/src/lib/deploy.sh
@@ -27,11 +27,17 @@ function deploy() {
   fi
 
   pushd "${_INPUTDIR}/dest"
+
+  # delete files created with "fill-dest"
+  find . -type f -empty -delete
+
+  # get files back to us
   if [[ "${CAUR_ENGINE}" = "singularity" ]]; then
     singularity --silent exec --fakeroot docker://alpine chown 0:0 .
   elif [[ -n "${CAUR_SIGN_USER}" ]]; then
     chown "${CAUR_SIGN_USER}" .
   fi
+
   for f in !(*.sig); do
     [[ "$f" == '!(*.sig)' ]] && continue
 
@@ -48,6 +54,7 @@ function deploy() {
       cp -v "$f"{,.sig} "${CAUR_DEST_PKG}/"
     fi
   done
+
   popd # "${_INPUTDIR}/dest"
 
   echo 'deployed' >"${_RESULT}"

--- a/src/lib/package-make.sh
+++ b/src/lib/package-make.sh
@@ -14,7 +14,9 @@ function makepkg() {
 }
 
 function makepkg-systemd-nspawn() {
-  local _INPUTDIR _PKGTAG _INTERFERE \
+  set -euo pipefail
+
+  local _INPUTDIR _PKGTAG _INTERFERE _ROOTDIR \
     _LOWER _HOME _CCACHE _SRCCACHE _PKGDEST \
     _CAUR_WIZARD _MECHA_NAME _BUILD_FAILED \
     _CONTAINER_ARGS
@@ -52,14 +54,16 @@ function makepkg-systemd-nspawn() {
     pwd -P
   )"
 
-  _HOME="machine/root/home/main-builder"
+  _ROOTDIR='machine/root'
+  _HOME="${_ROOTDIR}/home/main-builder"
   _CCACHE="${CAUR_CACHE_CC}/${_PKGTAG}"
   _SRCCACHE="${CAUR_CACHE_SRC}/${_PKGTAG}"
-  _PKGDEST="${_HOME}/pkgdest"
+  _PKGDEST="${_ROOTDIR}/var/pkgdest"
   _CAUR_WIZARD="machine/root/home/main-builder/${CAUR_BASH_WIZARD}"
 
   mkdir -p machine/{up,work,root} dest{,.work} "${_CCACHE}" "${_SRCCACHE}" "${CAUR_CACHE_PKG}" "${CAUR_DEST_PKG}"
   mount-overlayfs -olowerdir="${_LOWER}",upperdir='machine/up',workdir='machine/work' 'machine/root'
+  chown 1000:1000 'dest'
 
   mount --bind 'pkgwork' "${_HOME}/pkgwork"
   mount --bind "${_CCACHE}" "${_HOME}/.ccache"
@@ -102,6 +106,8 @@ function makepkg-systemd-nspawn() {
 }
 
 function makepkg-singularity() {
+  set -euo pipefail
+
   local _INPUTDIR _PKGTAG _INTERFERE \
     _LOWER _HOME _CCACHE _SRCCACHE _CAUR_WIZARD \
     _BUILD_FAILED _MECHA_NAME _SANDBOX
@@ -156,7 +162,7 @@ function makepkg-singularity() {
   _BUILD_FAILED=''
   singularity exec --writable --fakeroot --no-home --containall --workdir /tmp \
     -B "./pkgwork:${_HOME}/pkgwork" \
-    -B "./dest:${_HOME}/pkgdest" \
+    -B "./dest:/var/pkgdest" \
     -B "${_CCACHE}:${_HOME}/.ccache" \
     -B "${_SRCCACHE}:${_HOME}/pkgsrc" \
     -B "${CAUR_CACHE_PKG}:/var/cache/pacman/pkg" \

--- a/src/lib/utils.sh
+++ b/src/lib/utils.sh
@@ -21,10 +21,10 @@ function optional-parallel() {
 
   case "$_JOBN" in
   '0' | 'host' | 'n' | 'auto')
-    export CAUR_PARALLEL="$(nproc)"
+    CAUR_PARALLEL="$(nproc)"
     ;;
   [0-9]*)
-    export CAUR_PARALLEL="$_JOBN"
+    CAUR_PARALLEL="$_JOBN"
     ;;
   *)
     echo 'Wrong number of parallel jobs.'
@@ -32,5 +32,6 @@ function optional-parallel() {
     ;;
   esac
 
+  export CAUR_PARALLEL
   return 0
 }


### PR DESCRIPTION
* Move PKGDEST from `"~/pkgdest"` to `"/var/pkgdest"` -- This way it won't be caught in the home's `chown -R`.
* Change default CAUR_OVERLAY_TYPE to `kernel`;
* Readd `set -euo pipefail` that was miss-removed;
* Do linter complains.