### PR TITLE
Refactor parallelization

### DIFF
--- a/services/chaotic-afternoon.service
+++ b/services/chaotic-afternoon.service
@@ -7,11 +7,10 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic -j 4 routine afternoon
 
-TimeoutStartSec=21000
-TimeoutStartFailureMode=terminate
-KillSignal=SIGUSR1
-TimeoutStopSec=21600
+TimeoutStopSec=21000
 TimeoutStopFailureMode=abort
+WatchdogSignal=SIGUSR1
+TimeoutAbortSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-afternoon.service
+++ b/services/chaotic-afternoon.service
@@ -7,5 +7,11 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic -j 4 routine afternoon
 
+TimeoutStartSec=21000
+TimeoutStartFailureMode=terminate
+KillSignal=SIGUSR1
+TimeoutStopSec=21600
+TimeoutStopFailureMode=abort
+
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-hourly.service
+++ b/services/chaotic-hourly.service
@@ -7,11 +7,10 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic -j 0 routine hourly
 
-TimeoutStartSec=13800
-TimeoutStartFailureMode=terminate
-KillSignal=SIGUSR1
-TimeoutStopSec=14400
+TimeoutStopSec=13800
 TimeoutStopFailureMode=abort
+WatchdogSignal=SIGUSR1
+TimeoutAbortSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-hourly.service
+++ b/services/chaotic-hourly.service
@@ -7,5 +7,11 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic -j 0 routine hourly
 
+TimeoutStartSec=13800
+TimeoutStartFailureMode=terminate
+KillSignal=SIGUSR1
+TimeoutStopSec=14400
+TimeoutStopFailureMode=abort
+
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-midnight.service
+++ b/services/chaotic-midnight.service
@@ -7,11 +7,10 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic routine midnight
 
-TimeoutStartSec=21000
-TimeoutStartFailureMode=terminate
-KillSignal=SIGUSR1
-TimeoutStopSec=21600
+TimeoutStopSec=21000
 TimeoutStopFailureMode=abort
+WatchdogSignal=SIGUSR1
+TimeoutAbortSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-midnight.service
+++ b/services/chaotic-midnight.service
@@ -7,5 +7,11 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic routine midnight
 
+TimeoutStartSec=21000
+TimeoutStartFailureMode=terminate
+KillSignal=SIGUSR1
+TimeoutStopSec=21600
+TimeoutStopFailureMode=abort
+
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-morning.service
+++ b/services/chaotic-morning.service
@@ -7,5 +7,11 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic routine morning
 
+TimeoutStartSec=21000
+TimeoutStartFailureMode=terminate
+KillSignal=SIGUSR1
+TimeoutStopSec=21600
+TimeoutStopFailureMode=abort
+
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-morning.service
+++ b/services/chaotic-morning.service
@@ -7,11 +7,10 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic routine morning
 
-TimeoutStartSec=21000
-TimeoutStartFailureMode=terminate
-KillSignal=SIGUSR1
-TimeoutStopSec=21600
+TimeoutStopSec=21000
 TimeoutStopFailureMode=abort
+WatchdogSignal=SIGUSR1
+TimeoutAbortSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-nightly.service
+++ b/services/chaotic-nightly.service
@@ -7,5 +7,11 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic routine nightly
 
+TimeoutStartSec=21000
+TimeoutStartFailureMode=terminate
+KillSignal=SIGUSR1
+TimeoutStopSec=21600
+TimeoutStopFailureMode=abort
+
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-nightly.service
+++ b/services/chaotic-nightly.service
@@ -7,11 +7,10 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic routine nightly
 
-TimeoutStartSec=21000
-TimeoutStartFailureMode=terminate
-KillSignal=SIGUSR1
-TimeoutStopSec=21600
+TimeoutStopSec=21000
 TimeoutStopFailureMode=abort
+WatchdogSignal=SIGUSR1
+TimeoutAbortSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-tkg-kernels.service
+++ b/services/chaotic-tkg-kernels.service
@@ -7,11 +7,10 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic routine tkg-kernels
 
-TimeoutStartSec=85800
-TimeoutStartFailureMode=terminate
-KillSignal=SIGUSR1
-TimeoutStopSec=86400
+TimeoutStopSec=85800
 TimeoutStopFailureMode=abort
+WatchdogSignal=SIGUSR1
+TimeoutAbortSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-tkg-kernels.service
+++ b/services/chaotic-tkg-kernels.service
@@ -7,5 +7,11 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic routine tkg-kernels
 
+TimeoutStartSec=85800
+TimeoutStartFailureMode=terminate
+KillSignal=SIGUSR1
+TimeoutStopSec=86400
+TimeoutStopFailureMode=abort
+
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-tkg-wine.service
+++ b/services/chaotic-tkg-wine.service
@@ -7,11 +7,10 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic routine tkg-wine
 
-TimeoutStartSec=21000
-TimeoutStartFailureMode=terminate
-KillSignal=SIGUSR1
-TimeoutStopSec=21600
+TimeoutStopSec=21000
 TimeoutStopFailureMode=abort
+WatchdogSignal=SIGUSR1
+TimeoutAbortSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/services/chaotic-tkg-wine.service
+++ b/services/chaotic-tkg-wine.service
@@ -7,5 +7,11 @@ Group=chaotic_op
 WorkingDirectory=/tmp
 ExecStart=/usr/local/bin/chaotic routine tkg-wine
 
+TimeoutStartSec=21000
+TimeoutStartFailureMode=terminate
+KillSignal=SIGUSR1
+TimeoutStopSec=21600
+TimeoutStopFailureMode=abort
+
 [Install]
 WantedBy=multi-user.target

--- a/src/lib/base-make.sh
+++ b/src/lib/base-make.sh
@@ -5,7 +5,7 @@ function lowerstrap() {
 
   local _LOCK_FN _LOCK_FD
 
-  install -o"$(whoami)" -dDm755 "$CAUR_LOWER_DIR"
+  [[ ! -e "$CAUR_LOWER_DIR" ]] && install -o"$(whoami)" -dDm755 "$CAUR_LOWER_DIR"
 
   _LOCK_FN="${CAUR_LOWER_DIR}/lock"
   touch "${_LOCK_FN}"

--- a/src/lib/deploy.sh
+++ b/src/lib/deploy.sh
@@ -41,6 +41,7 @@ function deploy() {
     return 28
   fi
 
+  echo "Trying to deploy pacakges."
   _UPLOAD_PID=()
   for f in !(*.sig); do
     [[ "$f" == '!(*.sig)' ]] && continue
@@ -53,7 +54,8 @@ function deploy() {
     fi
 
     if [[ "$CAUR_TYPE" == 'cluster' ]]; then
-      rsync --partial "$f" "${CAUR_DEPLOY_HOST}:${CAUR_DEPLOY_PATH}" &
+      rsync --verbose --partial -e 'ssh -T -o Compression=no -x' -a \
+        "$f" "${CAUR_DEPLOY_HOST}:${CAUR_DEPLOY_PKGS}" &
       _UPLOAD_PID+=("$!")
     else
       cp -v "$f" "${CAUR_DEST_PKG}/"
@@ -62,12 +64,14 @@ function deploy() {
 
   [[ -n "${_UPLOAD_PID:-}" ]] && wait "${_UPLOAD_PID[@]}"
 
+  echo "Trying to deploy signatures."
   _UPLOAD_PID=()
   for f in *.sig; do
     [[ "$f" == '*.sig' ]] && continue
 
     if [[ "$CAUR_TYPE" == 'cluster' ]]; then
-      rsync --partial "$f" "${CAUR_DEPLOY_HOST}:${CAUR_DEPLOY_PATH}" &
+      rsync --verbose --partial -e 'ssh -T -o Compression=no -x' -a \
+        "$f" "${CAUR_DEPLOY_HOST}:${CAUR_DEPLOY_PKGS}/" &
       _UPLOAD_PID+=("$!")
     else
       cp -v "$f" "${CAUR_DEST_PKG}/"

--- a/src/lib/deploy.sh
+++ b/src/lib/deploy.sh
@@ -41,7 +41,7 @@ function deploy() {
     return 28
   fi
 
-  echo "Trying to deploy pacakges."
+  echo "Trying to deploy packages."
   _UPLOAD_PID=()
   for f in !(*.sig); do
     [[ "$f" == '!(*.sig)' ]] && continue

--- a/src/lib/package-makedir.sh
+++ b/src/lib/package-makedir.sh
@@ -35,7 +35,7 @@ function makepwd() {
       echo 'Trapped, waiting jobs until here.'
       wait "${_BUILDING_PIDS[@]}"
       _BUILDING_PIDS=()
-    elif [[ -z "${CAUR_PARALLEL:-}" ]]; then
+    elif [[ "${_MAX_JOBS}" == '1' ]]; then
       pipepkg "$_pkg"
     else
       while [[ -n "${_BUILDING_PIDS:-}" ]] \
@@ -73,7 +73,8 @@ function pipepkg() {
     return 24
   fi
 
-  (makepkg "${_pkg}" --noconfirm 2>&1 | tee "${_pkg}.log") \
+  echo "Starting making ${_pkg}"
+  (makepkg "${_pkg}" --noconfirm 2>&1 > "${_pkg}.log") \
     || true # we want to cleanup even if it failed
 
   {

--- a/src/lib/package-makedir.sh
+++ b/src/lib/package-makedir.sh
@@ -48,10 +48,8 @@ function makepwd() {
     fi
   done
 
-  if [[ ${_MAX_JOBS} -gt 1 ]]; then
-    echo 'Waiting all jobs to finish'
-    wait
-  fi
+  echo 'Waiting all jobs to finish'
+  wait
 
   return 0
 }
@@ -74,12 +72,12 @@ function pipepkg() {
   fi
 
   echo "Starting making ${_pkg}"
-  (makepkg "${_pkg}" --noconfirm 2>&1 > "${_pkg}.log") \
+  (makepkg "${_pkg}" --noconfirm 2>&1 | tee "${_pkg}.log") \
     || true # we want to cleanup even if it failed
 
   {
-    (deploy "${_pkg}" && db-bump) || true
-    (cleanup "${_pkg}") || true
+    (deploy "${_pkg}" && db-bump 2>&1 | tee -a "${_pkg}.log") || true
+    (cleanup "${_pkg}" 2>&1 | tee -a "${_pkg}.log") || true
   } &
 
   return 0

--- a/src/lib/routines-tkg-wine.sh
+++ b/src/lib/routines-tkg-wine.sh
@@ -5,6 +5,7 @@ function routine-tkg-wine() {
   iterfere-sync
   push-routine-dir 'tkg.wine' || return 12
 
+  [[ -d "_repo" ]] && rm -rf --one-file-system '_repo'
   git clone 'https://github.com/Frogging-Family/wine-tkg-git.git' '_repo'
 
   local _VARIATIONS _VARIATION _i _DEST _PROFILES
@@ -38,6 +39,6 @@ function routine-tkg-wine() {
 
   (makepwd) || true
   clean-logs
-  pop-routine-dir
+  popd #routine-dir
   return 0
 }

--- a/src/lib/routines-tkg-wine.sh
+++ b/src/lib/routines-tkg-wine.sh
@@ -3,7 +3,7 @@
 function routine-tkg-wine() {
   set -euo pipefail
   iterfere-sync
-  push-routine-dir 'tkg.wine' || return 12
+  push-routine-dir 'tkg.wine'
 
   [[ -d "_repo" ]] && rm -rf --one-file-system '_repo'
   git clone 'https://github.com/Frogging-Family/wine-tkg-git.git' '_repo'

--- a/src/lib/routines-tkg.sh
+++ b/src/lib/routines-tkg.sh
@@ -142,6 +142,6 @@ function routine-tkg-kernels() {
 
   (makepwd) || true
   clean-logs
-  pop-routine-dir
+  pop #routine-dir
   return 0
 }

--- a/src/lib/routines.sh
+++ b/src/lib/routines.sh
@@ -32,6 +32,8 @@ function routine() {
     ;;
   esac
 
+  echo 'Finished routine.'
+
   return 0
 }
 
@@ -133,9 +135,10 @@ function push-routine-dir() {
 
   if [[ -d "$_DIR" ]]; then
     pushd "$_DIR"
-    echo 'Cleaning pre-existent routine directory'
+    echo 'Cleaning pre-existent routine directory.'
     cleanpwd
   else
+    echo 'Creating new routine directory.'
     install -o"$(whoami)" -dDm755 "$_DIR"
     pushd "$_DIR"
   fi
@@ -147,7 +150,9 @@ function push-routine-dir() {
 }
 
 function freeze-notify() {
-  send-log "Hey onyii-san, wast ${1:-} buiwd on ${CAUR_CLUSTER_NAME}'s ${2:-} stawted lwng time ago (${CAUR_TELEGRAM_TAG})"
+  local _REMAINING
+  _REMAINING="$(find . -maxdepth 1 -type d | wc -l)"
+  send-log "Hey onyii-san, wast ${1:-} buiwd on ${CAUR_CLUSTER_NAME}'s ${2:-} stawted lwng time ago (${CAUR_TELEGRAM_TAG}), with ${_REMAINING} packages remaining to build."
 }
 
 function clean-archive() {

--- a/src/lib/routines.sh
+++ b/src/lib/routines.sh
@@ -87,8 +87,11 @@ function generic-routine() {
     done
 
   # put in background and wait, otherwise trap does not work
-  _PACKAGES=($(parse-package-list "${_LIST}" \
-    | sed -E 's/\:(.*)//g'))
+  _PACKAGES=()
+  mapfile -t _PACKAGES < <(
+    parse-package-list "${_LIST}" \
+      | sed -E 's/\:(.*)//g'
+  )
   makepwd "${_PACKAGES[@]}" &
   sane-wait "$!" || true
 
@@ -130,6 +133,7 @@ function push-routine-dir() {
 
   if [[ -d "$_DIR" ]]; then
     pushd "$_DIR"
+    echo 'Cleaning pre-existent routine directory'
     cleanpwd
   else
     install -o"$(whoami)" -dDm755 "$_DIR"
@@ -138,7 +142,7 @@ function push-routine-dir() {
 
   # shellcheck disable=SC2064
   trap "freeze-notify '$1' '${SLURM_NODELIST:-}'" SIGUSR1
-  
+
   return 0
 }
 


### PR DESCRIPTION
* Parallel upload of files/packages (instead of splitting a single file into smaller parts);
* Ensure sending signatures after packages;
* Get the building sequence from the routines' lists;
* Count build threads properly;
* External (systemd's unit) frozen notifier;
* Say remaining packages count in the frozen notification.

New time limits (systemd only):
* hourly: 4hrs
* morning/afternoon/nightly: 6hrs
* tkg-kernels: 24hrs
* tkg-wine: 6hrs