### PR TITLE
Fix typo in src/lib/deploy.sh

### DIFF
--- a/src/lib/deploy.sh
+++ b/src/lib/deploy.sh
@@ -52,7 +52,7 @@ function deploy() {
     return 17
   elif [[ ! -e "${_RESULT}" ]] \
     || [[ "$(cat "${_RESULT}")" != 'success' ]]; then
-    echo 'Invalid package, last build did not succeed, or aready deployed.'
+    echo 'Invalid package, last build did not succeed, or already deployed.'
     exec {_LOCK_FD}>&- # Unlock
     return 18
   fi


### PR DESCRIPTION
I wanted to deploy a package and saw this. Unacceptable.

Yes yes I know, stereotypical pull request, but this makes chaotic completely unusable let's be honest.