### PR TITLE
Switch to thin lto for LTO builds.

### DIFF
--- a/src/lib/routines-tkg.sh
+++ b/src/lib/routines-tkg.sh
@@ -49,7 +49,7 @@ function tkg-kernel-variate() {
   _LTO_MODE=''
   if [ "${_LTO}" == '1' ]; then
     _COMPILER='llvm'
-    _LTO_MODE='full'
+    _LTO_MODE='thin'
   fi
 
   sed -i'' "


### PR DESCRIPTION
In a few cases, ThinLTO even outperforms full LTO, most likely because the higher scalability of ThinLTO allows using a more aggressive backend optimization pipeline (similar to that of a non-LTO build). - [LLVM Blog](https://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html)

Thin LTO supports much better parallelism than fat LTO. It can achieve similar performance improvements as fat LTO (sometimes even better) while taking much less total time by taking advantage of more CPUs. - [Rust Lang blog](https://blog.rust-lang.org/inside-rust/2020/06/29/lto-improvements.html).

My understanding is that normally Full LTO disables some optimizations that don't scale with the increased size of the optimization unit, but because Thin LTO deals with smaller optimization units, it can keep these optimizations enabled, while additionally having some of the benefits of Full LTO.

So, we have only positive things here, in both compiling time and - probably - performance.

I personally have tested the builds here and they work perfectly, with no problems on `-dkms` drivers and general usage.

Signed-off-by: Edu4rdSHL <edu4rdshl@protonmail.com>