### PR TITLE
Enable parallel downloads by default.

### DIFF
--- a/guest/etc/pacman.conf
+++ b/guest/etc/pacman.conf
@@ -34,6 +34,7 @@ Architecture = auto
 #TotalDownload
 CheckSpace
 #VerbosePkgLists
+ParallelDownloads = 10
 
 # By default, pacman accepts packages signed by keys that its local keyring
 # trusts (see pacman-key and its man page), as well as unsigned packages.


### PR DESCRIPTION
It will speed up the downloading process.