### PR TITLE
Bump pkgrel via decimal bumps instead, support epoch, add chaotic {interfere-bump,bump}

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,14 @@ If at some point you see something that could be better, then please open a PR. 
   Prepare and build all packages in the current directory.
   If `PACKAGES` are not provided then it will try to build all sub-directories.
 
-- `chaotic {si,iterfere-sync}`
+- `chaotic {si,interfere-sync}`
 
   Sync packages' interference repo.
+
+- `chaotic {bump,interfere-bump} [${PACKAGES[@]}]`
+
+  Generate and push a PKGREL_BUMPS file for use in interfere. Old entries will automatically be removed.
+  Uses `repoctl`.
 
 - `chaotic {sp,package-lists-sync}`
 

--- a/src/chaotic.sh
+++ b/src/chaotic.sh
@@ -8,6 +8,7 @@ stee() { command tee "$@" >/dev/null; }
 pushd "$(dirname "$0")/.." || exit 2
 CAUR_PREFIX="$(pwd -P)"
 [[ -z "${HOME:-}" ]] && HOME="$(getent passwd "$(whoami)" | cut -d: -f6)"
+export HOME
 CAUR_MAINTAINER="${CAUR_REAL_USER:-${CAUR_REAL_UID:-${USER:-$UID}}}"
 popd || exit 2
 
@@ -114,8 +115,11 @@ function main() {
   'makepwd' | 'mkd')
     makepwd "${@:2}"
     ;;
-  'iterfere-sync' | 'si')
-    iterfere-sync "${@:2}"
+  'interfere-sync' | 'si')
+    interfere-sync "${@:2}"
+    ;;
+  'interfere-bump' | 'bump')
+    interference-bump "${@:2}"
     ;;
   'package-lists-sync' | 'sp')
     package-lists-sync "${@:2}"

--- a/src/lib/routines-tkg-wine.sh
+++ b/src/lib/routines-tkg-wine.sh
@@ -3,7 +3,7 @@
 function routine-tkg-wine() {
   set -euo pipefail
   clean-xdg
-  iterfere-sync
+  interfere-sync
   push-routine-dir 'tkg.wine'
 
   [[ -d "_repo" ]] && rm -rf --one-file-system '_repo'

--- a/src/lib/routines-tkg.sh
+++ b/src/lib/routines-tkg.sh
@@ -147,7 +147,7 @@ function tkg-kernels-variations() {
 function routine-tkg-kernels() {
   set -euo pipefail
   clean-xdg
-  iterfere-sync
+  interfere-sync
   push-routine-dir 'tkg.kernels' || return 12
 
   git clone 'https://github.com/Frogging-Family/linux-tkg.git' 'linux-tkg'

--- a/src/lib/routines.sh
+++ b/src/lib/routines.sh
@@ -68,7 +68,7 @@ function generic-routine() {
     return 22
   fi
 
-  (iterfere-sync)
+  (interfere-sync)
   (repoctl-sync-db)
 
   load-config "routines/$1"

--- a/src/lib/sync.sh
+++ b/src/lib/sync.sh
@@ -1,11 +1,24 @@
 #!/usr/bin/env bash
 
-function iterfere-sync() {
+function interfere-sync() {
   set -euo pipefail
 
   echo 'Syncing interfere...'
   pushd "${CAUR_INTERFERE}"
-  git pull --ff-only || true
+  git fetch || true
+  git reset --hard '@{u}' || true
+  popd #CAUR_INTERFERE
+
+  return 0
+}
+
+function interfere-push-bumps() {
+  set -euo pipefail
+
+  echo 'Push interfere...'
+  pushd "${CAUR_INTERFERE}"
+  GIT_AUTHOR_NAME="${CAUR_MAINTAINER}@$CAUR_DEPLOY_LABEL" git commit -m 'Update PKGREL_BUMPS' PKGREL_BUMPS \
+    && git push || return 1
   popd #CAUR_INTERFERE
 
   return 0


### PR DESCRIPTION
New procedure for rebuilding packages:

chaotic get package1 package2 package3
chaotic bump package1 package2 package3
chaotic mkd

No more chaotic rm! Yay!