### PR TITLE
Improve chaotic get

### DIFF
--- a/src/lib/aur.sh
+++ b/src/lib/aur.sh
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 
 function aur-download() {
-  repoctl down "$@"
+  set -euo pipefail
+
+  local _LIST _PACKAGES _PKGBASE _REPOCTL _GIT _OUT
+  _REPOCTL=()
+  declare -A _GIT
+  _PACKAGES="$(find "${CAUR_PACKAGE_LISTS}" -name '*.txt' | while read -r _LIST; do parse-package-list "$_LIST"; done)"
+  for _PKGBASE in "$@"; do
+    _OUT="$(awk -F ':' -v pkgbase="${_PKGBASE}" '$1==pkgbase { OFS = FS; $1=""; print substr($0, 2); exit }' <<<"$_PACKAGES")"
+    if [[ -z "${_OUT}" ]]; then
+      _REPOCTL+=("${_PKGBASE}")
+    else
+      _GIT["${_PKGBASE}"]="${_OUT}"
+    fi
+  done
+
+  if [ ${#_REPOCTL[@]} -ne 0 ]; then
+    repoctl down "${_REPOCTL[@]}"
+  fi
+  for _PKGBASE in "${!_GIT[@]}"; do
+    git clone --depth 1 "${_GIT[${_PKGBASE}]}" "${_PKGBASE}"
+  done
 }

--- a/src/lib/routines.sh
+++ b/src/lib/routines.sh
@@ -104,7 +104,7 @@ function generic-routine() {
   parse-package-list "${_LIST}" \
     | sed -En '/:/p' \
     | while IFS=':' read -r _DIR _URL; do
-      git clone "${_URL}" "${_DIR}" \
+      git clone --depth 1 "${_URL}" "${_DIR}" \
         | tee -a _repoctl_down.log \
         || true
     done


### PR DESCRIPTION
Chaotic get will now check the package lists to check if there is another source available for the package other than the aur. Sometimes we use external git sources directly instead of the aur, and this makes us download the correct package.