### PR TITLE
Add network-online.target dependency to services.

### DIFF
--- a/services/chaotic-afternoon.service
+++ b/services/chaotic-afternoon.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Chaotic's afternoon routine
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=root

--- a/services/chaotic-hourly.service
+++ b/services/chaotic-hourly.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Chaotic's hourly routine
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=root

--- a/services/chaotic-midnight.service
+++ b/services/chaotic-midnight.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Chaotic's midnight routine
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=root

--- a/services/chaotic-morning.service
+++ b/services/chaotic-morning.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Chaotic's morning routine
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=root

--- a/services/chaotic-nightly.service
+++ b/services/chaotic-nightly.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Chaotic's nightly routine
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=root

--- a/services/chaotic-sort-logs.service
+++ b/services/chaotic-sort-logs.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Chaotic's automatic log sorting utility
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=root

--- a/services/chaotic-tkg-kernels.service
+++ b/services/chaotic-tkg-kernels.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Chaotic+TkG's kernels routine
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=root

--- a/services/chaotic-tkg-wine.service
+++ b/services/chaotic-tkg-wine.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Chaotic+TkG's wine routine
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=root


### PR DESCRIPTION
It makes sense to add `network-online.target` as a dependency of the services since that they **requires** the network to be up. It helps a lot to solve problems like the following on machines that are constantly rebooted/hibernated like desktop computers/laptops:

_Logs are in reverse order_
```
Apr 25 23:08:02 CatBuilder systemd[1]: chaotic-tkg-kernels.service: Failed with result 'exit-code'.
Apr 25 23:08:02 CatBuilder systemd[1]: chaotic-tkg-kernels.service: Main process exited, code=exited, status=128/n/a
Apr 25 23:08:02 CatBuilder chaotic[58]: fatal: unable to access 'https://github.com/Frogging-Family/linux-tkg.git/': Could not resolve host: github.com
Apr 25 23:08:02 CatBuilder chaotic[56]: Cloning into 'linux-tkg'...
Apr 25 23:08:02 CatBuilder chaotic[55]: rm: cannot remove './*.lock': No such file or directory
Apr 25 23:08:02 CatBuilder chaotic[28]: Cleaning pre-existent routine directory.
Apr 25 23:08:02 CatBuilder chaotic[48]: HEAD is now at 79e3184 Update PKGREL_BUMPS
Apr 25 23:08:02 CatBuilder chaotic[46]: fatal: unable to access 'https://github.com/chaotic-aur/interfere.git/': Could not resolve host: github.com
Apr 25 23:08:02 CatBuilder chaotic[28]: Syncing interfere...
Apr 25 23:08:02 CatBuilder chaotic[28]: Skipping config file that was not found
Apr 25 23:08:02 CatBuilder chaotic[37]: No duplicate packages were found!
Apr 25 23:08:02 CatBuilder systemd[1]: Started Chaotic+TkG's kernels routine.
```

As a note, for it to really work, the user needs to enable `systemd-networkd-wait-online.service` if using `systemd-networkd` or `NetworkManager-wait-online.service` if using `NetworkManager`.

Signed-off-by: Eduard Tolosa <edu4rdshl@protonmail.com>