### PR TITLE
Linux-tkg 5.18 kernel builds shall start!

### DIFF
--- a/src/lib/routines-tkg.sh
+++ b/src/lib/routines-tkg.sh
@@ -110,7 +110,7 @@ function tkg-kernels-variations() {
   local _LINUX_LTS _LINUX_STABLE _LINUX_MARCH _VAR_SCHED _VAR_SCHED
 
   _LINUX_LTS='5.15'
-  _LINUX_STABLE='5.17'
+  _LINUX_STABLE='5.18'
 
   _LINUX_SCHED=(
     'bmq 1'


### PR DESCRIPTION
Needed to not build 5.17 kernel variations anymore and fix https://github.com/chaotic-aur/packages/issues/1458.