### PR TITLE
Add an additional mirror in case that the first one fails.

### DIFF
--- a/src/chaotic.sh
+++ b/src/chaotic.sh
@@ -18,7 +18,7 @@ CAUR_DB_NAME='chaotic-aur'
 CAUR_INTERFERE='/var/lib/chaotic/interfere'
 CAUR_PACKAGE_LISTS='/var/lib/chaotic/packages'
 
-CAUR_ARCH_MIRROR="Server = https://cloudflaremirrors.com/archlinux/\$repo/os/\$arch"
+CAUR_ARCH_MIRROR="Server = https://cloudflaremirrors.com/archlinux/\$repo/os/\$arch\nServer = https://mirror.rackspace.com/archlinux/\$repo/os/\$arch"
 CAUR_BASH_WIZARD='wizard.sh'
 CAUR_CACHE_CC="${CAUR_CACHE}/cc"
 CAUR_CACHE_PKG="${CAUR_CACHE}/packages"

--- a/src/lib/base-make.sh
+++ b/src/lib/base-make.sh
@@ -53,7 +53,7 @@ function lowerstrap-systemd-nspawn() {
   install -m644 "$CAUR_GUEST"/etc/pacman.conf './etc/pacman.conf'
   tee -a './etc/makepkg.conf' <"${CAUR_GUEST}/etc/makepkg.conf.append"
   if [[ -n "$CAUR_ARCH_MIRROR" ]]; then
-    echo "$CAUR_ARCH_MIRROR" | stee './etc/pacman.d/mirrorlist'
+    echo -e "$CAUR_ARCH_MIRROR" | stee './etc/pacman.d/mirrorlist'
   fi
   echo "PACKAGER=\"${CAUR_PACKAGER}\"" | tee -a './etc/makepkg.conf'
   install -m755 "$CAUR_GUEST"/bin/* './usr/local/bin/'


### PR DESCRIPTION
There are cases where the mirror from cloudflaremirrors fail, for example I'm getting a 500 response from cloudflaremirrors since some weeks ago and therefore the packages fail to build. The errors that I'm getting are (in reverse order):

```
Jun 22 21:07:25 CatBuilder systemd-machined[407]: Machine pkgfae4d382cef terminated.
Jun 22 21:07:25 CatBuilder systemd[1]: machine-pkgfae4d382cef.scope: Deactivated successfully.
Jun 22 21:07:25 CatBuilder chaotic[1003064]: [58B blob data]
Jun 22 21:07:25 CatBuilder chaotic[1003064]: error: failed to prepare transaction (could not find database)
Jun 22 21:07:25 CatBuilder chaotic[1003064]: warning: xz-5.2.5-3 is up to date -- skipping
Jun 22 21:07:25 CatBuilder chaotic[1003064]: warning: tar-1.34-1 is up to date -- skipping
Jun 22 21:07:25 CatBuilder chaotic[1003064]: warning: perl-5.36.0-1 is up to date -- skipping
Jun 22 21:07:25 CatBuilder chaotic[1003064]: warning: flex-2.6.4-3 is up to date -- skipping
Jun 22 21:07:25 CatBuilder chaotic[1003064]: warning: libelf-0.187-1 is up to date -- skipping
Jun 22 21:07:24 CatBuilder chaotic[1003064]: [54B blob data]
Jun 22 21:07:24 CatBuilder chaotic[1003064]: [82B blob data]
Jun 22 21:07:24 CatBuilder chaotic[1003064]: error: failed to synchronize all databases (failed to retrieve some files)
Jun 22 21:07:24 CatBuilder chaotic[1003064]: error: failed retrieving file 'core.db' from cloudflaremirrors.com : The requested URL returned error: 500
Jun 22 21:07:24 CatBuilder chaotic[1003064]: warning: too many errors from cloudflaremirrors.com, skipping for the remainder of this transaction
Jun 22 21:07:24 CatBuilder chaotic[1003064]: error: failed retrieving file 'multilib.db' from cloudflaremirrors.com : The requested URL returned error: 500
Jun 22 21:07:24 CatBuilder chaotic[1003064]: error: failed retrieving file 'community.db' from cloudflaremirrors.com : The requested URL returned error: 500
Jun 22 21:07:24 CatBuilder chaotic[1003064]: [290B blob data]
Jun 22 21:07:23 CatBuilder chaotic[1003064]:  chaotic-aur
Jun 22 21:07:23 CatBuilder chaotic[1003064]:  multilib
Jun 22 21:07:23 CatBuilder chaotic[1003064]:  community
Jun 22 21:07:23 CatBuilder chaotic[1003064]:  extra
Jun 22 21:07:23 CatBuilder chaotic[1003064]:  core
Jun 22 21:07:23 CatBuilder chaotic[1003064]: [43B blob data]
```

Adding an additional mirror prevent this kind of problem.

Note: the mirror from rackspace also works under a CDN, if you consideer that we should add another just let me know and I will update the PR.