### PR TITLE
Add db-rebuild subcommand to rebuild the database from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ If at some point you see something that could be better, then please open a PR. 
 - `chaotic {dbb,db-bump}`
 
   Add recently deployed packages to the database, while moving replaced packages to the archive.
-  Uses `repoctl`.
+
+- `chaotic {db-rebuild}`
+
+  Completely rebuild the database and files database from scratch, keeping the original DB around until the build is finished.
 
 - `chaotic {rm,remove} ${PACKAGES[@]}`
 

--- a/src/chaotic.sh
+++ b/src/chaotic.sh
@@ -142,6 +142,9 @@ function main() {
   'db-bump' | 'dbb')
     db-bump "${@:2}"
     ;;
+  'db-rebuild')
+    db-rebuild "${@:2}"
+    ;;
   'remove' | 'rm')
     remove "${@:2}"
     ;;

--- a/src/lib/utils.sh
+++ b/src/lib/utils.sh
@@ -122,7 +122,7 @@ function sort-logs() (
 
   if [[ "$CAUR_TYPE" != 'primary' ]]; then
     echo 'Only primary node can do this action.'
-    return 0
+    return 19
   fi
 
   # We don't want to have already fixed logs in there


### PR DESCRIPTION
Completely rebuild the database and files database from scratch, keeping the original DB around until the build is finished. This allows us to easily fix broken db entries without causing any downtime to chaotic.

This re-uses logic already used in db-bump.