### PR TITLE
Revert "Revert "Temporarily disable bcachefs" (#56)"

### DIFF
--- a/src/lib/routines-tkg.sh
+++ b/src/lib/routines-tkg.sh
@@ -52,6 +52,7 @@ function tkg-kernel-variate() {
     _LTO_MODE='thin'
   fi
 
+  # bcachefs is temporarily set to false as a hotfix for https://github.com/Frogging-Family/linux-tkg/issues/550
   sed -i'' "
   s/_distro=\"[^\"]*\"/_distro=\"Arch\"/g
   s/_version=\"[^\"]*\"/_version=\"${_VER}\"/g
@@ -72,7 +73,7 @@ function tkg-kernel-variate() {
   s/_voluntary_preempt=\"[^\"]*\"/_voluntary_preempt=\"false\"/g
   s/_acs_override=\"[^\"]*\"/_acs_override=\"true\"/g
   s/_ksm_uksm=\"[^\"]*\"/_ksm_uksm=\"true\"/g
-  s/_bcachefs=\"[^\"]*\"/_bcachefs=\"true\"/g
+  s/_bcachefs=\"[^\"]*\"/_bcachefs=\"false\"/g
   s/_bfqmq=\"[^\"]*\"/_bfqmq=\"true\"/g
   s/_zfsfix=\"[^\"]*\"/_zfsfix=\"true\"/g
   s/_fsync=\"[^\"]*\"/_fsync=\"true\"/g

--- a/src/lib/routines-tkg.sh
+++ b/src/lib/routines-tkg.sh
@@ -52,7 +52,6 @@ function tkg-kernel-variate() {
     _LTO_MODE='thin'
   fi
 
-  # bcachefs is temporarily set to false as a hotfix for https://github.com/Frogging-Family/linux-tkg/issues/550
   sed -i'' "
   s/_distro=\"[^\"]*\"/_distro=\"Arch\"/g
   s/_version=\"[^\"]*\"/_version=\"${_VER}\"/g


### PR DESCRIPTION
This reverts commit a4c2deb016bfd73f9efb29fdf072562949d4f4f6. We are
disabling bcachefs on our main builds from now, bcachefs will be moved to
new kernel variants with -bcachefs in its name to avoid the patch
breaking the main kernels every time.