### PR TITLE
Change to the base docker image to the base-devel one

### DIFF
--- a/guest/Singularity
+++ b/guest/Singularity
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: gitlab.archlinux.org:5050/archlinux/archlinux-docker:base-master
+From: gitlab.archlinux.org:5050/archlinux/archlinux-docker:base-devel
 
 %files
   /etc/mtab /etc/
@@ -22,7 +22,6 @@ Server = https://builds.garudalinux.org/repos/chaotic-aur/x86_64
 EOF
 
   pacman -Syyu --noconfirm --noprogressbar --quiet
-  pacman -S --noconfirm --noprogressbar --quiet base base-devel
 
   echo 'en_US.UTF-8 UTF-8' | stee '/etc/locale.gen'
   echo 'LANG=en_US.UTF-8' | stee '/etc/locale.conf'


### PR DESCRIPTION
Signed-off-by: Gontier Julien <gontierjulien68@gmail.com>

As discussed here #59 we are going now to directly grab the base-devel image from archlinux.
(it also save a bit of time and is more efficient :D)