### PR TITLE
Some nixos compatiblity changes

### DIFF
--- a/src/lib/package-make.sh
+++ b/src/lib/package-make.sh
@@ -97,6 +97,7 @@ function makepkg-systemd-nspawn() {
     -u "root" \
     --suppress-sync=true \
     --capability=CAP_IPC_LOCK,CAP_SYS_NICE \
+    --bind-ro=/etc/hosts:/etc/hosts \
     -D machine/root ${_CONTAINER_ARGS:-} \
     "/home/main-builder/wizard.sh" "${@:2}" || local _BUILD_FAILED="$?"
 

--- a/src/lib/package-prepare.sh
+++ b/src/lib/package-prepare.sh
@@ -59,7 +59,7 @@ function makepkg-gen-bash-init() {
 
   export CAUR_WIZARD="${_DEST}/${CAUR_BASH_WIZARD}"
   stee "${CAUR_WIZARD}" <<EOF
-#!/usr/bin/env bash
+#!/usr/bin/bash
 source /etc/profile
 
 EOF


### PR DESCRIPTION
1. Ensure the hosts file is respected inside the systemd-nspawn container
2. hardcode path of bash in the wizard (env is not yet initialized)