### PR TITLE
Add basic resilience against failed builds

### DIFF
--- a/src/lib/package-makedir.sh
+++ b/src/lib/package-makedir.sh
@@ -61,7 +61,6 @@ function pipepkg() {
   set -euo pipefail
 
   local _pkg
-  local _already_failed
 
   if [ ${#@} -ne 1 ]; then
     echo 'Invalid number of parameters.'
@@ -77,14 +76,14 @@ function pipepkg() {
 
   echo "Starting making ${_pkg}"
   ({ time makepkg "${_pkg}" --noconfirm; } 2>&1 | tee "${_pkg}.log") \
-    || if grep -qP "is not a clone of" "${_pkg}.log" && [ -z "${_already_failed}" ]; then
+    || if grep -qP "is not a clone of" "${_pkg}.log"; then
       clean-srccache "${_pkg}" # To fight failed builds due to changed git source
       ({ time makepkg "${_pkg}" --noconfirm; } 2>&1 | tee "${_pkg}.log") \
-        || _already_failed=1 && true
-    elif grep -qP "One or more files did not pass the validity check!" "${_pkg}.log" && [ -z "${_already_failed}" ]; then
+        || true
+    elif grep -qP "One or more files did not pass the validity check!" "${_pkg}.log"; then
       clean-srccache "${_pkg}" # To fight failed builds due to wrong cached files
       ({ time makepkg "${_pkg}" --noconfirm; } 2>&1 | tee "${_pkg}.log") \
-        || _already_failed=1 && true
+        || true
     fi \
     || true # we want to cleanup even if it failed
 

--- a/src/lib/package-makedir.sh
+++ b/src/lib/package-makedir.sh
@@ -76,6 +76,13 @@ function pipepkg() {
 
   echo "Starting making ${_pkg}"
   ({ time makepkg "${_pkg}" --noconfirm; } 2>&1 | tee "${_pkg}.log") \
+    || if grep -qP "is not a clone of" "${_pkg}.log"; then
+      clean-srccache "${_pkg}" # To fight failed builds due to changed git source
+      ({ time makepkg "${_pkg}" --noconfirm; } 2>&1 | tee "${_pkg}.log") \
+        || true
+    elif grep -qP "One or more files did not pass the validity check!" "${_pkg}.log"; then
+      clean-srccache "${_pkg}" # To fight failed builds due to wrong cached files
+    fi \
     || true # we want to cleanup even if it failed
 
   (deploy "${_pkg}" && db-bump 2>&1 | tee -a "${_pkg}.log") || true

--- a/src/lib/package-makedir.sh
+++ b/src/lib/package-makedir.sh
@@ -77,10 +77,12 @@ function pipepkg() {
   echo "Starting making ${_pkg}"
   ({ time makepkg "${_pkg}" --noconfirm; } 2>&1 | tee "${_pkg}.log") \
     || if grep -qP "is not a clone of" "${_pkg}.log"; then
+      echo 'The cached git repo is invalid, clearing source and retrying.'
       clean-srccache "${_pkg}" # To fight failed builds due to changed git source
       ({ time makepkg "${_pkg}" --noconfirm; } 2>&1 | tee "${_pkg}.log") \
         || true
     elif grep -qP "One or more files did not pass the validity check!" "${_pkg}.log"; then
+      echo 'The cached file did not pass validity check, clearing source and retrying.'
       clean-srccache "${_pkg}" # To fight failed builds due to wrong cached files
       ({ time makepkg "${_pkg}" --noconfirm; } 2>&1 | tee "${_pkg}.log") \
         || true

--- a/src/lib/package-makedir.sh
+++ b/src/lib/package-makedir.sh
@@ -82,6 +82,8 @@ function pipepkg() {
         || true
     elif grep -qP "One or more files did not pass the validity check!" "${_pkg}.log"; then
       clean-srccache "${_pkg}" # To fight failed builds due to wrong cached files
+      ({ time makepkg "${_pkg}" --noconfirm; } 2>&1 | tee "${_pkg}.log") \
+        || true
     fi \
     || true # we want to cleanup even if it failed
 


### PR DESCRIPTION
Basically, the idea is to get us rid of having to clear source caches by hand by checking the log of the failed build for known patterns indicating cache cleaning. 