### PR TITLE
Start pkgrel_increment service in background during routines

### DIFF
--- a/install-hpc-cluster.sh
+++ b/install-hpc-cluster.sh
@@ -32,9 +32,13 @@ CAUR_TELEGRAM_TAG='@thotypous'
 EOF
 
 mkdir -p "${HOME}/chaotic"
-for repo in toolbox interfere packages; do
+for repo in toolbox interfere packages pkgrel_incrementer; do
   [[ -d "${HOME}/chaotic/${repo}" ]] || git clone "https://github.com/chaotic-aur/${repo}.git" "${HOME}/chaotic/${repo}"
 done
+
+pushd "${HOME}/chaotic/toolbox/pkgrel_incrementer"
+make
+popd
 
 pushd "${HOME}/chaotic/toolbox/src"
 ln -sf "./chaotic.sh" "./chaotic"

--- a/src/lib/pkgrel-incrementer.sh
+++ b/src/lib/pkgrel-incrementer.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+function pkgrel-incrementer-start() {
+  set -euo pipefail
+
+  if [[ "${CAUR_ENGINE}" = 'singularity' ]]; then
+    singularity run -B "$HOME/chaotic/pkgrel_incrementer/data":/data "$HOME/chaotic/pkgrel_incrementer/pkgrel_incrementer.sif" &
+    PKGREL_INCREMENTER_PID="$!"
+  fi
+}
+
+function pkgrel-incrementer-stop() {
+  set -euo pipefail
+
+  if [[ -n "${PKGREL_INCREMENTER_PID:-}" ]]; then
+    kill "${PKGREL_INCREMENTER_PID}"
+  fi
+}

--- a/src/lib/routines.sh
+++ b/src/lib/routines.sh
@@ -109,6 +109,8 @@ function generic-routine() {
         || true
     done
 
+  (pkgrel-incrementer-start)
+
   # put in background and wait, otherwise trap does not work
   _PACKAGES=()
   mapfile -t _PACKAGES < <(
@@ -117,6 +119,8 @@ function generic-routine() {
   )
   makepwd "${_PACKAGES[@]}" &
   sane-wait "$!" || true
+
+  (pkgrel-incrementer-stop)
 
   cleanpwd
   popd #routine dir


### PR DESCRIPTION
Only for the Singularity engine (for now?)

I know, this is utterly hackish. Changes already in production on the Slurm cluster.