### PR TITLE
Use alternate method to get rid of PKGEXT, groups, replaces

### DIFF
--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -81,12 +81,13 @@ function interference-generic() {
   $CAUR_PUSH pacman -Syu --noconfirm "${extra_pkgs[@]}"
 
   # * Add missing newlines at end of file
-  printf '\n\n\n' >> PKGBUILD
-
   # * Get rid of troublesome options
-  echo 'unset PKGEXT' >> PKGBUILD
-  echo 'unset groups' >> PKGBUILD
-  echo 'unset replaces' >> PKGBUILD
+  {
+    echo -e '\n\n\n'
+    echo 'unset PKGEXT'
+    echo 'unset groups'
+    echo 'unset replaces'
+  } >>PKGBUILD
 
   # * Get rid of 'native optimizations'
   if (grep -qP '\-march=native' PKGBUILD); then

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -80,21 +80,13 @@ function interference-generic() {
   # * CHROOT Update
   $CAUR_PUSH pacman -Syu --noconfirm "${extra_pkgs[@]}"
 
-  # * People who think they're smart
-  if (grep -qP '^\s*PKGEXT=' PKGBUILD); then
-    sed -i'' 's/^\s*PKGEXT=.*$//g' PKGBUILD
-  fi
+  # * Add missing newlines at end of file
+  printf '\n\n\n' >> PKGBUILD
 
-  # * Get rid of groups
-  if (grep -qP '^\s*groups=' PKGBUILD); then
-    sed -i'' 's/^\s*groups=.*$//g' PKGBUILD
-  fi
-
-  # * replaces=() (for VCS packages) generally causes unnecessary problems and should be avoided.
-  # * https://wiki.archlinux.org/title/VCS_package_guidelines#Guidelines
-  if [[ -n "${_PKGTAG_NON_VCS:-}" ]] && (grep -qP "^\s*replaces=\(${_PKGTAG_NON_VCS}\)$" PKGBUILD); then
-    sed -i'' "/^\s*replaces=(${_PKGTAG_NON_VCS})$/d" PKGBUILD
-  fi
+  # * Get rid of troublesome options
+  echo 'unset PKGEXT' >> PKGBUILD
+  echo 'unset groups' >> PKGBUILD
+  echo 'unset replaces' >> PKGBUILD
 
   # * Get rid of 'native optimizations'
   if (grep -qP '\-march=native' PKGBUILD); then


### PR DESCRIPTION
Use alternate method to get rid of PKGEXT, groups, replaces.  `sed` fails to catch many cases.  Use `unset` instead.

Add missing newline at end of PKGBUILD.  Packages that are missing a newline at the end of the file abort without doing anything.

<details><summary>nuclear-player-bin.log</summary>

```
Building package "nuclear-player-bin"
:: Synchronizing package databases...
 core downloading...
 extra downloading...
 community downloading...
 multilib downloading...
 chaotic-aur downloading...
:: Starting full system upgrade...
 there is nothing to do
umount: /home/xiota/nuclear-player-bin/machine/root/home/main-builder/pkgwork unmounted
umount: /home/xiota/nuclear-player-bin/machine/root/home/main-builder/.ccache unmounted
umount: /home/xiota/nuclear-player-bin/machine/root/home/main-builder/pkgsrc unmounted
umount: /home/xiota/nuclear-player-bin/machine/root/var/cache/pacman/pkg unmounted
umount: /home/xiota/nuclear-player-bin/machine/root/var/pkgdest unmounted
umount: /home/xiota/nuclear-player-bin/machine/root (overlay) unmounted

real	0m1.111s
user	0m0.205s
sys	0m0.355s
```
</details>

Closes #89