### PR TITLE
Fix PKGEXT

### DIFF
--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -84,7 +84,7 @@ function interference-generic() {
   # * Get rid of troublesome options
   {
     echo -e '\n\n\n'
-    echo 'unset PKGEXT'
+    echo "PKGEXT='.pkg.tar.zst'"
     echo 'unset groups'
     echo 'unset replaces'
   } >>PKGBUILD


### PR DESCRIPTION
#93 causes following message because of `unset PKGEXT`. This replaces it with `PKGEXT='.pkg.tar.zst'`.

```
==> WARNING: '' is not a valid archive extension.
```

@dr460nf1r3 @PedroHLC