### PR TITLE
Add optdep to track interfered packages

### DIFF
--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -8,6 +8,8 @@ function interference-apply() {
 
   interference-generic "${_PKGTAG}"
 
+  [[ -d "${_INTERFERE}" ]] && echo 'optdepends+=("chaotic-interfere")' >>PKGBUILD
+
   # shellcheck source=/dev/null
   [[ -f "${_INTERFERE}/prepare" ]] \
     && source "${_INTERFERE}/prepare"


### PR DESCRIPTION
An idea to make tracking interfered packages easier.  Add an optdep on `chaotic-interfere` to interfered packages.  Shouldn't affect building, and the following command would show a list of interfered packages in the repository (would need to create a dummy package):
```
pactree -usr -o1 -d1 chaotic-interfere
```

Not using:

* `depends` - interferes with build / install.  However, would make visible in logs that an interfere was used.
* `makedepends` - interferes with build / install, and not visible afterwards.  Would be visible in logs.  Maybe use in combination with optdep?
* `pkgdesc` - difficult to cover all cases.
* Something else - I probably don't know it exists.