### PR TITLE
Improve performance of interference-bump

### DIFF
--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -225,7 +225,10 @@ function interference-bump() {
     _BUMPS=$(sed -E 's&^('"${_LINE% *}"') '"${_BUMP}"'$&\1 '"$((_BUMP + 1))"'&' <<<"${_BUMPS}")
   done
 
-  echo "${_BUMPS_BRK}"
+  # show broken packages without version info
+  echo "${_BUMPS_BRK}" | sed -E 's& .*$&&' | sort -u
+
+  # save bumps file
   echo "${_BUMPS}" >"${_BUMPSFILE}"
 
   interfere-push-bumps || interfere-sync

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -227,7 +227,7 @@ function interference-bump() {
       _LINE=$(grep -E "^$_PKGTAG " <<<"$_PACKAGES" || true)
       _BUMPS+=$'\n'"$_LINE"
     fi
-    if [[ ! -z "$_LINE" ]]; then
+    if [[ -n "$_LINE" ]]; then
       _BUMP=$(sed -E 's&^.* ([0-9]+)&\1&' <<<"$_LINE")
       _BUMPS=$(sed -E 's&^('"${_LINE% *}"') '"$_BUMP"'$&\1 '"$((_BUMP + 1))"'&' <<<"$_BUMPS")
     fi

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -160,7 +160,7 @@ function interference-bump() {
   _PACKAGES="$(
     repoctl list -v \
       | sed -E \
-        -e 's@-([0-9]+\S*)$@-\1 0@'
+        -e 's@-([0-9]+\S*)$@-\1 0@' \
         -e 's@-([0-9]+)(\.([0-9]+)) 0$@-\1 \3@' \
       | sort -u
   )"
@@ -176,7 +176,7 @@ function interference-bump() {
   # collect existing versions of packages
   _BUMPS_TMP+=$(
     echo
-    while IFS= read -r _LINE ; do
+    while read -r _LINE ; do
       [[ -z "$_LINE" ]] && continue
       grep -E '^'"${_LINE%% *}"'\b .*$' <<< "$_PACKAGES"
     done <<< "$_BUMPS_TMP"
@@ -211,7 +211,7 @@ function interference-bump() {
   # remove updated packages from bump list
   _BUMPS_TMP=$(sed -E 's& .*$&&' <<< "$_BUMPS_UPD")
 
-  while read _LINE ; do
+  while read -r _LINE ; do
     [[ -z "$_LINE" ]] && continue
     _BUMPS=$(
       sed -E "s&^$_LINE .*+\$&&" <<< "$_BUMPS"

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -177,27 +177,21 @@ function interference-bump() {
     echo
     while read -r _LINE; do
       [[ -z "${_LINE}" ]] && continue
-      grep -E '^'"${_LINE%% *}"'\b .*$' <<<"${_PACKAGES}"
+      grep -Esm1 '^'"${_LINE%% *}"'\b .*$' <<<"${_PACKAGES}"
     done <<<"${_BUMPS_TMP}"
   )
 
-  _BUMPS_TMP=$(
+  _BUMPS_BRK=$(
     echo
     sort -u <<<"${_BUMPS_TMP}"
   )
 
-  _BUMPS_BRK="${_BUMPS_TMP}"
-
   # remove broken packages; keep updated packages
-  _BUMPS_TMP=$(
+  _BUMPS_UPD=$(
     sed -Ez \
       -e 's&\n(\S+ \S+) \S+\n\1 \S+\n&\n\n&g' \
       -e 's&\n(\S+ \S+) \S+\n\1 \S+\n&\n\n&g' \
-      <<<"${_BUMPS_TMP}"
-  )
-
-  _BUMPS_UPD=$(
-    sort -u <<<"${_BUMPS_TMP}"
+      <<<"${_BUMPS_BRK}" | sort -u || true
   )
 
   # collect broken packages only
@@ -221,10 +215,10 @@ function interference-bump() {
   for _PKGTAG in "$@"; do
     [[ -z "$_PKGTAG" ]] && continue
     # increase existing bump
-    _LINE=$(grep -E "^$_PKGTAG " <<<"$_BUMPS" || true)
+    _LINE=$(grep -Esm1 "^$_PKGTAG " <<<"$_BUMPS" || true)
     if [[ -z "$_LINE" ]]; then
       # add new bump
-      _LINE=$(grep -E "^$_PKGTAG " <<<"$_PACKAGES" || true)
+      _LINE=$(grep -Esm1 "^$_PKGTAG " <<<"$_PACKAGES" || true)
       _BUMPS+=$'\n'"$_LINE"
     fi
     if [[ -n "$_LINE" ]]; then

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -26,8 +26,8 @@ function interference-apply() {
     # The worst one, but KISS and easier to maintain
     _PREPEND="$(cat "${_INTERFERE}/PKGBUILD.prepend")"
     _PKGBUILD="$(cat PKGBUILD)"
-    echo "${_PREPEND}" >PKGBUILD
-    echo "${_PKGBUILD}" >>PKGBUILD
+    echo "$_PREPEND" >PKGBUILD
+    echo "$_PKGBUILD" >>PKGBUILD
   fi
 
   [[ -f "${_INTERFERE}/PKGBUILD.append" ]] \
@@ -47,30 +47,30 @@ function interference-generic() {
   _PKGTAG="${1:-}"
 
   # * Treats VCs
-  if (echo "${_PKGTAG}" | grep -qP '\-git$'); then
+  if (echo "$_PKGTAG" | grep -qP '\-git$'); then
     extra_pkgs+=("git")
     _PKGTAG_NON_VCS="${_PKGTAG%-git}"
   fi
-  if (echo "${_PKGTAG}" | grep -qP '\-svn$'); then
+  if (echo "$_PKGTAG" | grep -qP '\-svn$'); then
     extra_pkgs+=("subversion")
     _PKGTAG_NON_VCS="${_PKGTAG%-svn}"
   fi
-  if (echo "${_PKGTAG}" | grep -qP '\-bzr$'); then
+  if (echo "$_PKGTAG" | grep -qP '\-bzr$'); then
     extra_pkgs+=("breezy")
     _PKGTAG_NON_VCS="${_PKGTAG%-bzr}"
   fi
-  if (echo "${_PKGTAG}" | grep -qP '\-hg$'); then
+  if (echo "$_PKGTAG" | grep -qP '\-hg$'); then
     extra_pkgs+=("mercurial")
     _PKGTAG_NON_VCS="${_PKGTAG%-hg}"
   fi
 
   # * Multilib
-  if (echo "${_PKGTAG}" | grep -qP '^lib32-'); then
+  if (echo "$_PKGTAG" | grep -qP '^lib32-'); then
     extra_pkgs+=("multilib-devel")
   fi
 
   # * Special cookie for TKG kernels
-  if (echo "${_PKGTAG}" | grep -qP '^linux.*tkg'); then
+  if (echo "$_PKGTAG" | grep -qP '^linux.*tkg'); then
     extra_pkgs+=("git")
   fi
 
@@ -80,7 +80,7 @@ function interference-generic() {
   fi
 
   # * CHROOT Update
-  ${CAUR_PUSH} pacman -Syu --noconfirm "${extra_pkgs[@]}"
+  $CAUR_PUSH pacman -Syu --noconfirm "${extra_pkgs[@]}"
 
   # * Add missing newlines at end of file
   # * Get rid of troublesome options
@@ -107,7 +107,7 @@ function interference-pkgrel() {
   _PKGTAG="${1:-}"
   _BUMPSFILE="${CAUR_INTERFERE}/PKGREL_BUMPS"
 
-  if [[ ! -f "${_BUMPSFILE}" ]]; then
+  if [ ! -f "${_BUMPSFILE}" ]; then
     return 0
   fi
 
@@ -137,7 +137,7 @@ esac" >>PKGBUILD
 function interference-makepkg() {
   set -euo pipefail
 
-  ${CAUR_PUSH} exec /usr/local/bin/internal-makepkg --skippgpcheck "$@" "${TARGET_ARGS:-}" \$\@
+  $CAUR_PUSH exec /usr/local/bin/internal-makepkg --skippgpcheck "$@" "${TARGET_ARGS:-}" \$\@
 
   return 0
 }

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -182,7 +182,7 @@ function interference-bump() {
   )
 
   # _BUMPS_RVW will contain packages that need review.
-  # These are usually packages that have yet to be rebuils.
+  # These are usually packages that have yet to be rebuilt.
   # The pkgver and pkgrel match, but bump is still mismatched.
   _BUMPS_RVW=$(
     echo

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -156,7 +156,7 @@ function interference-bump() {
     _BUMPS=""
   fi
 
-  # put into format: [name] [version]-pkgrel bump
+  # format: [name] [version]-pkgrel bump
   _PACKAGES="$(
     repoctl list -v \
       | sed -E \
@@ -165,7 +165,6 @@ function interference-bump() {
       | sort -u
   )"
 
-  ## Clear old bumps
   # collect packages that have not been rebuilt
   _BUMPS_TMP=$(
     comm -13 \
@@ -201,7 +200,7 @@ function interference-bump() {
     sort -u <<<"${_BUMPS_TMP}"
   )
 
-  # keep broken packages only
+  # collect broken packages only
   _BUMPS_BRK=$(
     comm -23 \
       <(sort -u <<<"${_BUMPS_BRK}" || true) \
@@ -214,7 +213,7 @@ function interference-bump() {
   while read -r _LINE; do
     [[ -z "${_LINE}" ]] && continue
     _BUMPS=$(
-      sed -E "s&^${_LINE} .*+\$&&" <<<"${_BUMPS}"
+      sed -E "/^${_LINE} .*+\$/d" <<<"${_BUMPS}"
     )
   done <<<"${_BUMPS_TMP}"
 

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -26,8 +26,8 @@ function interference-apply() {
     # The worst one, but KISS and easier to maintain
     _PREPEND="$(cat "${_INTERFERE}/PKGBUILD.prepend")"
     _PKGBUILD="$(cat PKGBUILD)"
-    echo "$_PREPEND" >PKGBUILD
-    echo "$_PKGBUILD" >>PKGBUILD
+    echo "${_PREPEND}" >PKGBUILD
+    echo "${_PKGBUILD}" >>PKGBUILD
   fi
 
   [[ -f "${_INTERFERE}/PKGBUILD.append" ]] \
@@ -47,30 +47,30 @@ function interference-generic() {
   _PKGTAG="${1:-}"
 
   # * Treats VCs
-  if (echo "$_PKGTAG" | grep -qP '\-git$'); then
+  if (echo "${_PKGTAG}" | grep -qP '\-git$'); then
     extra_pkgs+=("git")
     _PKGTAG_NON_VCS="${_PKGTAG%-git}"
   fi
-  if (echo "$_PKGTAG" | grep -qP '\-svn$'); then
+  if (echo "${_PKGTAG}" | grep -qP '\-svn$'); then
     extra_pkgs+=("subversion")
     _PKGTAG_NON_VCS="${_PKGTAG%-svn}"
   fi
-  if (echo "$_PKGTAG" | grep -qP '\-bzr$'); then
+  if (echo "${_PKGTAG}" | grep -qP '\-bzr$'); then
     extra_pkgs+=("breezy")
     _PKGTAG_NON_VCS="${_PKGTAG%-bzr}"
   fi
-  if (echo "$_PKGTAG" | grep -qP '\-hg$'); then
+  if (echo "${_PKGTAG}" | grep -qP '\-hg$'); then
     extra_pkgs+=("mercurial")
     _PKGTAG_NON_VCS="${_PKGTAG%-hg}"
   fi
 
   # * Multilib
-  if (echo "$_PKGTAG" | grep -qP '^lib32-'); then
+  if (echo "${_PKGTAG}" | grep -qP '^lib32-'); then
     extra_pkgs+=("multilib-devel")
   fi
 
   # * Special cookie for TKG kernels
-  if (echo "$_PKGTAG" | grep -qP '^linux.*tkg'); then
+  if (echo "${_PKGTAG}" | grep -qP '^linux.*tkg'); then
     extra_pkgs+=("git")
   fi
 
@@ -80,7 +80,7 @@ function interference-generic() {
   fi
 
   # * CHROOT Update
-  $CAUR_PUSH pacman -Syu --noconfirm "${extra_pkgs[@]}"
+  ${CAUR_PUSH} pacman -Syu --noconfirm "${extra_pkgs[@]}"
 
   # * Add missing newlines at end of file
   # * Get rid of troublesome options
@@ -107,7 +107,7 @@ function interference-pkgrel() {
   _PKGTAG="${1:-}"
   _BUMPSFILE="${CAUR_INTERFERE}/PKGREL_BUMPS"
 
-  if [ ! -f "${_BUMPSFILE}" ]; then
+  if [[ ! -f "${_BUMPSFILE}" ]]; then
     return 0
   fi
 
@@ -137,7 +137,7 @@ esac" >>PKGBUILD
 function interference-makepkg() {
   set -euo pipefail
 
-  $CAUR_PUSH exec /usr/local/bin/internal-makepkg --skippgpcheck "$@" "${TARGET_ARGS:-}" \$\@
+  ${CAUR_PUSH} exec /usr/local/bin/internal-makepkg --skippgpcheck "$@" "${TARGET_ARGS:-}" \$\@
 
   return 0
 }
@@ -169,8 +169,8 @@ function interference-bump() {
   # collect packages that have not been rebuilt
   _BUMPS_TMP=$(
     comm -13 \
-      <(sort -u <<< "${_PACKAGES}") \
-      <(sort -u <<< "${_BUMPS}")
+      <(sort -u <<< "${_PACKAGES}" || true) \
+      <(sort -u <<< "${_BUMPS}" || true)
   )
 
   # collect existing versions of packages
@@ -204,8 +204,8 @@ function interference-bump() {
   # keep broken packages only
   _BUMPS_BRK=$(
     comm -23 \
-      <(sort -u <<< "${_BUMPS_BRK}" ) \
-      <(sort -u <<< "${_BUMPS_UPD}" )
+      <(sort -u <<< "${_BUMPS_BRK}" || true) \
+      <(sort -u <<< "${_BUMPS_UPD}" || true)
   )
 
   # remove updated packages from bump list

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -150,7 +150,7 @@ function interference-bump() {
 
   _BUMPSFILE="${CAUR_INTERFERE}/PKGREL_BUMPS"
 
-  if [ -f "${_BUMPSFILE}" ]; then
+  if [[ -f "${_BUMPSFILE}" ]]; then
     _BUMPS=$(sort -u "${_BUMPSFILE}")
   else
     _BUMPS=""
@@ -169,61 +169,61 @@ function interference-bump() {
   # collect packages that have not been rebuilt
   _BUMPS_TMP=$(
     comm -13 \
-      <(sort -u <<< "$_PACKAGES") \
-      <(sort -u <<< "$_BUMPS")
+      <(sort -u <<< "${_PACKAGES}") \
+      <(sort -u <<< "${_BUMPS}")
   )
 
   # collect existing versions of packages
   _BUMPS_TMP+=$(
     echo
     while read -r _LINE ; do
-      [[ -z "$_LINE" ]] && continue
-      grep -E '^'"${_LINE%% *}"'\b .*$' <<< "$_PACKAGES"
-    done <<< "$_BUMPS_TMP"
+      [[ -z "${_LINE}" ]] && continue
+      grep -E '^'"${_LINE%% *}"'\b .*$' <<< "${_PACKAGES}"
+    done <<< "${_BUMPS_TMP}"
   )
 
   _BUMPS_TMP=$(
     echo
-    sort -u <<< "$_BUMPS_TMP"
+    sort -u <<< "${_BUMPS_TMP}"
   )
 
-  _BUMPS_BRK="$_BUMPS_TMP"
+  _BUMPS_BRK="${_BUMPS_TMP}"
 
   # remove broken packages; keep updated packages
   _BUMPS_TMP=$(
     sed -Ez \
       -e 's&\n(\S+ \S+) \S+\n\1 \S+\n&\n\n&g' \
       -e 's&\n(\S+ \S+) \S+\n\1 \S+\n&\n\n&g' \
-      <<< "$_BUMPS_TMP"
+      <<< "${_BUMPS_TMP}"
   )
 
   _BUMPS_UPD=$(
-    sort -u <<< "$_BUMPS_TMP"
+    sort -u <<< "${_BUMPS_TMP}"
   )
 
   # keep broken packages only
   _BUMPS_BRK=$(
     comm -23 \
-      <(sort -u <<< "$_BUMPS_BRK" ) \
-      <(sort -u <<< "$_BUMPS_UPD" )
+      <(sort -u <<< "${_BUMPS_BRK}" ) \
+      <(sort -u <<< "${_BUMPS_UPD}" )
   )
 
   # remove updated packages from bump list
-  _BUMPS_TMP=$(sed -E 's& .*$&&' <<< "$_BUMPS_UPD")
+  _BUMPS_TMP=$(sed -E 's& .*$&&' <<< "${_BUMPS_UPD}")
 
   while read -r _LINE ; do
-    [[ -z "$_LINE" ]] && continue
+    [[ -z "${_LINE}" ]] && continue
     _BUMPS=$(
-      sed -E "s&^$_LINE .*+\$&&" <<< "$_BUMPS"
+      sed -E "s&^${_LINE} .*+\$&&" <<< "${_BUMPS}"
     )
-  done <<< "$_BUMPS_TMP"
+  done <<< "${_BUMPS_TMP}"
 
   # Add/increase existing bumps
   for _PKGTAG in "$@"; do
-    [[ -z "$_PKGTAG" ]] && continue
-    _LINE=$(grep -E "^$_PKGTAG " <<< "$_BUMPS")
-    _BUMP=$(sed -E 's&^.* ([0-9]+)&\1&' <<< "$_LINE")
-    _BUMPS=$(sed -E 's&^('"${_LINE% *}"') '"$_BUMP"'$&\1 '"$((_BUMP+1))"'&' <<< "$_BUMPS")
+    [[ -z "${_PKGTAG}" ]] && continue
+    _LINE=$(grep -E "^${_PKGTAG} " <<< "${_BUMPS}")
+    _BUMP=$(sed -E 's&^.* ([0-9]+)&\1&' <<< "${_LINE}")
+    _BUMPS=$(sed -E 's&^('"${_LINE% *}"') '"${_BUMP}"'$&\1 '"$((_BUMP+1))"'&' <<< "${_BUMPS}")
   done
 
   echo "${_BUMPS_BRK}"

--- a/src/lib/interfere.sh
+++ b/src/lib/interfere.sh
@@ -8,14 +8,14 @@ function interference-apply() {
 
   interference-generic "${_PKGTAG}"
 
-  [[ -d "${_INTERFERE}" ]] && echo 'optdepends+=("chaotic-interfere")' >>PKGBUILD
+  [[ -d "${_INTERFERE}" ]] && echo 'optdepends+=("chaotic-interfere")' >> PKGBUILD
 
   # shellcheck source=/dev/null
   [[ -f "${_INTERFERE}/prepare" ]] \
     && source "${_INTERFERE}/prepare"
 
   if [[ -f "${_INTERFERE}/interfere.patch" ]]; then
-    if patch -Np1 <"${_INTERFERE}/interfere.patch"; then
+    if patch -Np1 < "${_INTERFERE}/interfere.patch"; then
       echo 'Patches applied with success'
     else
       echo 'Ignoring patch failure...'
@@ -26,12 +26,12 @@ function interference-apply() {
     # The worst one, but KISS and easier to maintain
     _PREPEND="$(cat "${_INTERFERE}/PKGBUILD.prepend")"
     _PKGBUILD="$(cat PKGBUILD)"
-    echo "${_PREPEND}" >PKGBUILD
-    echo "${_PKGBUILD}" >>PKGBUILD
+    echo "${_PREPEND}" > PKGBUILD
+    echo "${_PKGBUILD}" >> PKGBUILD
   fi
 
   [[ -f "${_INTERFERE}/PKGBUILD.append" ]] \
-    && cat "${_INTERFERE}/PKGBUILD.append" >>PKGBUILD
+    && cat "${_INTERFERE}/PKGBUILD.append" >> PKGBUILD
 
   interference-pkgrel "${_PKGTAG}"
 
@@ -89,7 +89,7 @@ function interference-generic() {
     echo "PKGEXT='.pkg.tar.zst'"
     echo 'unset groups'
     echo 'unset replaces'
-  } >>PKGBUILD
+  } >> PKGBUILD
 
   # * Get rid of 'native optimizations'
   if (grep -qP '\-march=native' PKGBUILD); then
@@ -111,7 +111,7 @@ function interference-pkgrel() {
     return 0
   fi
 
-  IFS=";" read -r _EPOCH _PKGVER _PKGREL _BUMPCOUNT <<<"$(awk -v pkgtag="${_PKGTAG}" '$1==pkgtag { epoch_index=index($2,":"); pkgrel_index=index($2,"-"); print (epoch_index==0 ? "0" : substr($2,0,epoch_index-1)) ";" substr($2,epoch_index+1,pkgrel_index-epoch_index-1) ";" substr($2,pkgrel_index+1) ";" $3; exit}' "${_BUMPSFILE}")"
+  IFS=";" read -r _EPOCH _PKGVER _PKGREL _BUMPCOUNT <<< "$(awk -v pkgtag="${_PKGTAG}" '$1==pkgtag { epoch_index=index($2,":"); pkgrel_index=index($2,"-"); print (epoch_index==0 ? "0" : substr($2,0,epoch_index-1)) ";" substr($2,epoch_index+1,pkgrel_index-epoch_index-1) ";" substr($2,pkgrel_index+1) ";" $3; exit}' "${_BUMPSFILE}")"
 
   if [[ -z "${_EPOCH}" ]] || [[ -z "${_PKGVER}" ]] || [[ -z "${_PKGREL}" ]]; then
     return 0
@@ -131,7 +131,7 @@ function interference-pkgrel() {
       pkgrel=\"\$pkgrel.${_BUMPCOUNT}\"
     fi
     ;;
-esac" >>PKGBUILD
+esac" >> PKGBUILD
 }
 
 function interference-makepkg() {
@@ -176,7 +176,7 @@ function interference-bump() {
   # collect existing versions of packages
   _BUMPS_TMP+=$(
     echo
-    while read -r _LINE ; do
+    while read -r _LINE; do
       [[ -z "${_LINE}" ]] && continue
       grep -E '^'"${_LINE%% *}"'\b .*$' <<< "${_PACKAGES}"
     done <<< "${_BUMPS_TMP}"
@@ -211,7 +211,7 @@ function interference-bump() {
   # remove updated packages from bump list
   _BUMPS_TMP=$(sed -E 's& .*$&&' <<< "${_BUMPS_UPD}")
 
-  while read -r _LINE ; do
+  while read -r _LINE; do
     [[ -z "${_LINE}" ]] && continue
     _BUMPS=$(
       sed -E "s&^${_LINE} .*+\$&&" <<< "${_BUMPS}"
@@ -223,7 +223,7 @@ function interference-bump() {
     [[ -z "${_PKGTAG}" ]] && continue
     _LINE=$(grep -E "^${_PKGTAG} " <<< "${_BUMPS}")
     _BUMP=$(sed -E 's&^.* ([0-9]+)&\1&' <<< "${_LINE}")
-    _BUMPS=$(sed -E 's&^('"${_LINE% *}"') '"${_BUMP}"'$&\1 '"$((_BUMP+1))"'&' <<< "${_BUMPS}")
+    _BUMPS=$(sed -E 's&^('"${_LINE% *}"') '"${_BUMP}"'$&\1 '"$((_BUMP + 1))"'&' <<< "${_BUMPS}")
   done
 
   echo "${_BUMPS_BRK}"
@@ -239,7 +239,7 @@ function interference-finish() {
   unset TARGET_ARGS || true
 
   if [[ -n "${TARGET_RUN:-}" ]]; then
-    echo "${TARGET_RUN}" >'CONTAINER_ARGS'
+    echo "${TARGET_RUN}" > 'CONTAINER_ARGS'
   fi
 
   unset TARGET_RUN || true


### PR DESCRIPTION
More verbose, but 21-25x speed-up.

Test scripts: [bump_old.sh](https://github.com/chaotic-aur/toolbox/files/13238070/bump_old.txt), [bump_new.sh](https://github.com/chaotic-aur/toolbox/files/13244128/bump_new.txt)

```bash
$ time ./bump_old.sh acidrip zrythm zulucrypt

cmd: ./bump_old.sh acidrip zrythm zulucrypt
cpu: 100%
mem: 57
usr: 18.319
sys: 6.261
tot: 24.382

$ time ./bump_new.sh acidrip zrythm zulucrypt

cmd: ./bump_new.sh acidrip zrythm zulucrypt
cpu: 104%
mem: 56
usr: 0.851
sys: 0.178
tot: 0.983
```

Performance note: Original function was O(n^2) because it has nested n-loops.  Revised function is O(n log n) because of use of `sort`.  If not for sort, it would be O(n) because the outer loops are over small lists, O(1).  Expected performance should be close to O(n) because package lists should be already sorted.  It looks more inefficient because of repeated O(1) and O(n) blocks.  But they combine to O(n).

Behavior change.  Instead of printing entire PKGREL_BUMPS file, prints only bumped packages that haven't been rebuilt yet (without version info) because they are probably broken.  Current output:
```
mate-panel-genmon-git
meshlab
meshlab-git
multimc5
mutter-performance
obs-streamfx
pixelorama-git
python-pympv
qucs
servo-git
vim-coc-sh-git
vscodium-electron
```