### PR TITLE
chore: don't silence telegram notifications output to gather logs

### DIFF
--- a/src/lib/utils.sh
+++ b/src/lib/utils.sh
@@ -104,7 +104,7 @@ function clean-xdg() {
 function send-group() {
   # group messages cannot be silenced
 
-  telegram-send --config "$CAUR_TELEGRAM" "$@" &>/dev/null || true
+  telegram-send --config "$CAUR_TELEGRAM" "$@" || true
 
   return 0
 }
@@ -112,7 +112,7 @@ function send-group() {
 function send-log() {
   [[ "$CAUR_SILENT" == '1' ]] && return 0
 
-  telegram-send --config "$CAUR_TELEGRAM_LOG" --silent "$@" &>/dev/null || true
+  telegram-send --config "$CAUR_TELEGRAM_LOG" --silent "$@" || true
 
   return 0
 }


### PR DESCRIPTION
To find out why the user part of the deploy logs isn't working anymore after updating `telegram-send`.
 
https://github.com/rahiel/telegram-send/issues/109#issuecomment-1784163104


