### PR TITLE
feat: add Garuda routine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ LIBS = \
 	package-prepare \
 	pkgrel-incrementer \
 	routines \
+	routines-garuda \
 	routines-tkg \
 	routines-tkg-wine \
 	sync \
@@ -26,6 +27,7 @@ ROUTINES = \
 	afternoon \
 	nightly \
 	midnight \
+	garuda \
 	tkg-kernels \
 	tkg-wine
 

--- a/src/lib/routines-garuda.sh
+++ b/src/lib/routines-garuda.sh
@@ -9,7 +9,7 @@ function routine-garuda() {
   [[ -d "_repo" ]] && rm -rf --one-file-system '_repo'
   git clone 'https://gitlab.com/garuda-linux/pkgbuilds.git' '_repo'
   mv _repo/* .
-  
+
   (makepwd) || true
 
   clean-logs

--- a/src/lib/routines-garuda.sh
+++ b/src/lib/routines-garuda.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+function routine-garuda() {
+  set -euo pipefail
+  clean-xdg
+  interfere-sync
+  push-routine-dir 'garuda'
+
+  [[ -d "_repo" ]] && rm -rf --one-file-system '_repo'
+  git clone 'https://gitlab.com/garuda-linux/pkgbuilds.git' '_repo'
+  mv _repo/* .
+  
+  (makepwd) || true
+
+  clean-logs
+  popd #routine-dir
+  return 0
+}

--- a/src/lib/routines.sh
+++ b/src/lib/routines.sh
@@ -14,6 +14,10 @@ function routine() {
   export CAUR_IN_ROUTINE
 
   case "${_CMD}" in
+  'garuda')
+    load-config 'routines/garuda'
+    routine-garuda
+    ;;
   'tkg-kernels')
     load-config 'routines/tkg-kernels'
     routine-tkg-kernels


### PR DESCRIPTION
I'm planning to consolidate all PKGBUILD repos Garuda currently has into [one repo](https://gitlab.com/garuda-linux/pkgbuilds) to simplify maintenance and make finding individual PKGBUILDs easier for potential contributors. 

Since the toolbox currently does not support PKGBUILDs not residing in a single repo, a workaround had to be implemented. 

