### PR TITLE
hpc: use all cores+mem available

### DIFF
--- a/slurm-jobs/ufscar-hpc/daily.1.sh
+++ b/slurm-jobs/ufscar-hpc/daily.1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH --job-name=daily.1
-#SBATCH --cpus-per-task 40
-#SBATCH --mem 257500M
+#SBATCH --mincpus 40
+#SBATCH --exclusive
 #SBATCH --partition fast
 #SBATCH --nodes 1
 #SBATCH --dependency=singleton

--- a/slurm-jobs/ufscar-hpc/hourly.1.sh
+++ b/slurm-jobs/ufscar-hpc/hourly.1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH --job-name=hourly.1
-#SBATCH --cpus-per-task 40
-#SBATCH --mem 257500M
+#SBATCH --mincpus 40
+#SBATCH --exclusive
 #SBATCH --partition fast
 #SBATCH --nodes 1
 #SBATCH --dependency=singleton

--- a/slurm-jobs/ufscar-hpc/hourly.2.sh
+++ b/slurm-jobs/ufscar-hpc/hourly.2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH --job-name=hourly.2
-#SBATCH --cpus-per-task 40
-#SBATCH --mem 257500M
+#SBATCH --mincpus 40
+#SBATCH --exclusive
 #SBATCH --partition fast
 #SBATCH --nodes 1
 #SBATCH --dependency=singleton


### PR DESCRIPTION
The old code worked nice when all the computer-nodes were the same, but since we added the 2x32x2 EPICs we weren't using all the available cores, and some apps were even wrongly detecting the topology overloading the pinned cores.