### PR TITLE
clean-duplicates: escape '+' in filenames

### DIFF
--- a/src/lib/cleanup.sh
+++ b/src/lib/cleanup.sh
@@ -134,6 +134,7 @@ function clean-duplicates() {
     _TO_MV=$(
       echo "${_DUPLICATED[@]}" \
         | awk '{print "find -name \""$1"*\" -printf \"%T@ %p\\n\" | sort -n | grep -Po \"\\.\\/"$1"(((-[^-]*){3}\\.pkg\\.tar(?>\\.xz|\\.zst)?))\\.sig$\" | head -n -1;"}' \
+        | sed 's/\+/\\+/g' \
         | bash \
         | awk '{sub(/\.sig$/,"");print $1"\n"$1".sig"}'
     )


### PR DESCRIPTION
`chaotic dedup` misses filenames containing `+` because it's a special symbol in `grep` (Perl/Extended) regular expressions.  `find` seems to work with escaped or unescaped `+`.