### PR TITLE
makepkg.conf.append: OPTIONS=(... !debug ...)

### DIFF
--- a/guest/etc/makepkg.conf.append
+++ b/guest/etc/makepkg.conf.append
@@ -5,3 +5,4 @@ LOGDEST=/home/main-builder/makepkglogs
 JOBS=8
 MAKEFLAGS="-j$JOBS"
 export SCONSFLAGS="-j$JOBS"
+OPTIONS=(strip docs !libtool !staticlibs emptydirs zipman purge !debug lto)


### PR DESCRIPTION
This PR disables the `debug` flag, which is the old default.  Arch enables it by default in `makepkg.conf` since about 2024-02-06.